### PR TITLE
Hotfix/crashes: Fixed app crashing when doing various activities

### DIFF
--- a/app/src/main/java/ca/unb/mobiledev/phototrek/AlbumListRecyclerAdapter.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/AlbumListRecyclerAdapter.java
@@ -39,22 +39,25 @@ public class AlbumListRecyclerAdapter extends RecyclerView.Adapter<AlbumListRecy
         Album album = mAlbums.get(position);
         holder.mTextTitle.setText(album.getTitle());
 
-        int coverImagePosition = album.getCoverImagePosition();
-        if (coverImagePosition == -1) {
+        try {
+            setCoverPhoto(holder, album);
+        } catch (IndexOutOfBoundsException e) {
             holder.mCoverPhoto.setImageResource(R.drawable.ic_empty_album);
-        } else {
-            String photoPath = album.getPhotos().get(coverImagePosition).getAbsolutePath();
-            String thumbnailPath = album.getPhotos().get(coverImagePosition).getThumbnailPath();
-            if (photoPath == null) {
-                holder.mCoverPhoto.setImageResource(R.drawable.ic_empty_album);
-            } else {
-                ImageViewCompat.setImageTintList(holder.mCoverPhoto, null);
-                Bitmap thumbnail = BitmapFactory.decodeFile(thumbnailPath);
-                holder.mCoverPhoto.setImageBitmap(thumbnail);
-            }
         }
 
         holder.mCurrentPosition = position;
+    }
+
+    private void setCoverPhoto(ViewHolder holder, Album album) throws IndexOutOfBoundsException {
+        String photoPath = album.getPhotos().get(album.getCoverImagePosition()).getAbsolutePath();
+        String thumbnailPath = album.getPhotos().get(album.getCoverImagePosition()).getThumbnailPath();
+        if (photoPath == null) {
+            holder.mCoverPhoto.setImageResource(R.drawable.ic_empty_album);
+        } else {
+            ImageViewCompat.setImageTintList(holder.mCoverPhoto, null);
+            Bitmap thumbnail = BitmapFactory.decodeFile(thumbnailPath);
+            holder.mCoverPhoto.setImageBitmap(thumbnail);
+        }
     }
 
     @Override

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/AlbumPhotoViewActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/AlbumPhotoViewActivity.java
@@ -75,6 +75,15 @@ public class AlbumPhotoViewActivity extends AppCompatActivity {
             }
         });
 
+        FloatingActionButton refreshFab = findViewById(R.id.fab_refresh_map);
+        refreshFab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                finish();
+                startActivity(getIntent());
+            }
+        });
+
         Intent intent = getIntent();
         mAlbumPosition = intent.getIntExtra(ALBUM_POSITION, -1);
         mAlbum = dataManager.getAllAlbums().get(mAlbumPosition);

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/DataManager.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/DataManager.java
@@ -20,7 +20,7 @@ public class DataManager extends SQLiteOpenHelper {
     private final String TAG = "DataManager";
 
     public DataManager(@Nullable Context context) {
-        super(context, "database.db", null, 3);
+        super(context, "database.db", null, 8);
     }
 
     @Override
@@ -215,8 +215,16 @@ public class DataManager extends SQLiteOpenHelper {
         SQLiteDatabase db = this.getWritableDatabase();
         String selection = PhotoSchema._ID + " = " + photo.getId();
 
+        updateAlbumCoverImagePosition(photo.getAlbumId());
+
         int count = db.delete(PhotoSchema.PHOTO_TABLE, selection, null);
         return count == 1;
+    }
+
+    private void updateAlbumCoverImagePosition(int albumId) {
+        Album album = getAlbumById(albumId);
+        album.setCoverImagePosition(album.getCoverImagePosition() - 1);
+        updateAlbum(album);
     }
 
     public boolean updatePhoto(Photo photo) {

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/MapActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/MapActivity.java
@@ -69,6 +69,16 @@ public class MapActivity extends AppCompatActivity {
                 dispatchTakePictureIntent();
             }
         });
+
+        FloatingActionButton refreshFab = findViewById(R.id.fab_refresh_map);
+        refreshFab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                finish();
+                startActivity(getIntent());
+            }
+        });
+
         initializeMap();
 
         int PERMISSION_ALL = 1;

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/SavePhotoActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/SavePhotoActivity.java
@@ -219,22 +219,31 @@ public class SavePhotoActivity extends AppCompatActivity {
         } else {
             Album destinationAlbum = dataManager.getAllAlbums().get(mSpinnerAlbums.getSelectedItemPosition());
 
+            int previousAlbumId = mPhoto.getAlbumId();
+
             mPhoto.setAlbumId(destinationAlbum.getId());
             mPhoto.setDescription(mTextDescription.getText().toString());
             dataManager.updatePhoto(mPhoto);
 
-            // Photo was moved to a different album. Update cover image.
-            if (originalAlbum != destinationAlbum) {
-                int destinationAlbumSize = dataManager.getAlbumById(destinationAlbum.getId()).getPhotos().size();
-                int originalAlbumSize = dataManager.getAlbumById(originalAlbum.getId()).getPhotos().size();
-                destinationAlbum.setCoverImagePosition(destinationAlbumSize - 1);
-                originalAlbum.setCoverImagePosition(originalAlbumSize - 1);
-                dataManager.updateAlbum(destinationAlbum);
-                dataManager.updateAlbum(originalAlbum);
+            if (previousAlbumId != mPhoto.getAlbumId()) {
+                updatePreviousAlbumCoverImagePosition(previousAlbumId);
+                updateDestinationAlbumCoverImagePosition(mPhoto.getAlbumId());
             }
 
             finish();
         }
+    }
+
+    private void updatePreviousAlbumCoverImagePosition(int previousAlbumId) {
+        Album previousAlbum = dataManager.getAlbumById(previousAlbumId);
+        previousAlbum.setCoverImagePosition(previousAlbum.getCoverImagePosition() - 1);
+        dataManager.updateAlbum(previousAlbum);
+    }
+
+    private void updateDestinationAlbumCoverImagePosition(int destinationAlbumId) {
+        Album destinationAlbum = dataManager.getAlbumById(destinationAlbumId);
+        destinationAlbum.setCoverImagePosition(destinationAlbum.getCoverImagePosition() + 1);
+        dataManager.updateAlbum(destinationAlbum);
     }
 
     private void hideKeyboard() {

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/ViewPhotoActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/ViewPhotoActivity.java
@@ -9,6 +9,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -39,6 +40,15 @@ public class ViewPhotoActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo_view);
 
+        try {
+            setUpPhotoViewActivity();
+        } catch (Exception e) {
+            Toast.makeText(this, "Error loading photo.", Toast.LENGTH_SHORT).show();
+            finish();
+        }
+    }
+
+    private void setUpPhotoViewActivity() throws Exception {
         Intent intent = getIntent();
         mPhotoPosition = intent.getIntExtra(PHOTO_POSITION, 0);
         mAlbumId = intent.getIntExtra(ALBUMID, 0);

--- a/app/src/main/java/ca/unb/mobiledev/phototrek/ViewPhotoActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/phototrek/ViewPhotoActivity.java
@@ -43,7 +43,7 @@ public class ViewPhotoActivity extends AppCompatActivity {
         try {
             setUpPhotoViewActivity();
         } catch (Exception e) {
-            Toast.makeText(this, "Error loading photo.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "Error loading photo. Try the refreshing map.", Toast.LENGTH_SHORT).show();
             finish();
         }
     }

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -30,6 +30,20 @@
         app:fabSize="auto"
         app:srcCompat="@drawable/ic_camera" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_refresh_map"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="90dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="0dp"
+        app:fabSize="mini"
+        app:srcCompat="@android:drawable/ic_popup_sync" />
+
     <include
         layout="@layout/content_maps"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_photo_list.xml
+++ b/app/src/main/res/layout/activity_photo_list.xml
@@ -21,6 +21,20 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_refresh_map"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="90dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="0dp"
+        app:fabSize="mini"
+        app:srcCompat="@android:drawable/ic_popup_sync" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_new_photo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
**Fixed the following issues:**
* Deleting a photo then immediately clicking it’s associated google maps marker can cause the app to crash. 
* Deleting a photo immediately after switching it’s album results in the app continually crashing, requiring a fresh install. 


**Tested by:**
* Following the steps to replicate as described above